### PR TITLE
Add placeholder image support for products without gallery images

### DIFF
--- a/view/frontend/templates/product/view/gallery-vertical.phtml
+++ b/view/frontend/templates/product/view/gallery-vertical.phtml
@@ -22,9 +22,18 @@ $productName = $block->escapeHtml($product->getName());
 /** @var \Magento\Framework\Data\Collection $images */
 $images = $product->getMediaGalleryImages();
 
-// Don't render if no images
-if (!$images || $images->getSize() === 0) {
-    return;
+// Detect placeholder mode when product has no images
+$isPlaceholder = (!$images || $images->getSize() === 0);
+$placeholderUrl = '';
+
+if ($isPlaceholder) {
+    // Use Magento's built-in placeholder fallback from the Gallery block
+    $galleryDataJson = $block->getGalleryImagesJson();
+    $galleryData = json_decode($galleryDataJson, true);
+    $placeholderUrl = !empty($galleryData[0]['img']) ? $galleryData[0]['img'] : '';
+    if (empty($placeholderUrl)) {
+        return;
+    }
 }
 
 // Get ViewModel
@@ -44,6 +53,11 @@ $stickyEnabled = $galleryConfig->isStickyEnabled();
 $stickyMode = $galleryConfig->getStickyMode();
 $stickyOffset = $galleryConfig->getStickyOffset();
 
+// Disable interactive features for placeholder
+if ($isPlaceholder) {
+    $zoomType = 'disabled';
+}
+
 // Build CSS classes
 $wrapperClasses = [
     'rp-product-gallery',
@@ -52,6 +66,10 @@ $wrapperClasses = [
     'rp-mobile-' . $mobileBehavior,
     'rp-zoom-' . $zoomType
 ];
+
+if ($isPlaceholder) {
+    $wrapperClasses[] = 'rp-placeholder';
+}
 
 if ($stickyEnabled) {
     $wrapperClasses[] = 'rp-sticky-' . $stickyMode;
@@ -148,27 +166,34 @@ $gridImageColumns = $columnCss['gridImageColumns'] ?? 2;
     <?php endif; ?>
 
         <div class="rp-gallery-images">
-            <?php foreach ($images as $image): ?>
-                <?php
-                $largeImageUrl = $image->getData('large_image_url') ?: $image->getData('url');
-                $mediumImageUrl = $image->getData('medium_image_url') ?: $image->getData('url');
-                $imageLabel = $image->getData('label') ?: $productName;
-                ?>
-                <a href="<?= $block->escapeUrl($largeImageUrl) ?>"
-                   class="rp-gallery-item <?= $zoomType === 'lightbox' ? 'glightbox' : '' ?>"
-                   data-gallery="product-gallery"
-                   <?php if ($zoomType === 'lightbox'): ?>
-                   data-glightbox="title: <?= $block->escapeHtmlAttr($imageLabel) ?>"
-                   <?php endif; ?>>
-                    <img src="<?= $block->escapeUrl($mediumImageUrl) ?>"
-                         alt="<?= $block->escapeHtmlAttr($imageLabel) ?>"
-                         loading="lazy"/>
-                </a>
-            <?php endforeach; ?>
+            <?php if ($isPlaceholder): ?>
+                <span class="rp-gallery-item rp-placeholder-item">
+                    <img src="<?= $block->escapeUrl($placeholderUrl) ?>"
+                         alt="<?= $block->escapeHtmlAttr($productName) ?>"/>
+                </span>
+            <?php else: ?>
+                <?php foreach ($images as $image): ?>
+                    <?php
+                    $largeImageUrl = $image->getData('large_image_url') ?: $image->getData('url');
+                    $mediumImageUrl = $image->getData('medium_image_url') ?: $image->getData('url');
+                    $imageLabel = $image->getData('label') ?: $productName;
+                    ?>
+                    <a href="<?= $block->escapeUrl($largeImageUrl) ?>"
+                       class="rp-gallery-item <?= $zoomType === 'lightbox' ? 'glightbox' : '' ?>"
+                       data-gallery="product-gallery"
+                       <?php if ($zoomType === 'lightbox'): ?>
+                       data-glightbox="title: <?= $block->escapeHtmlAttr($imageLabel) ?>"
+                       <?php endif; ?>>
+                        <img src="<?= $block->escapeUrl($mediumImageUrl) ?>"
+                             alt="<?= $block->escapeHtmlAttr($imageLabel) ?>"
+                             loading="lazy"/>
+                    </a>
+                <?php endforeach; ?>
+            <?php endif; ?>
         </div>
 
     <?php if ($layoutType === 'slider'): ?>
-        <?php if ($sliderArrows): ?>
+        <?php if ($sliderArrows && !$isPlaceholder): ?>
         <button class="rp-slider-prev" type="button" aria-label="<?= $block->escapeHtmlAttr(__('Previous image')) ?>">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
         </button>
@@ -176,13 +201,13 @@ $gridImageColumns = $columnCss['gridImageColumns'] ?? 2;
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
         </button>
         <?php endif; ?>
-        <?php if ($sliderDots): ?>
+        <?php if ($sliderDots && !$isPlaceholder): ?>
         <div class="rp-slider-dots" data-role="rp-slider-dots"></div>
         <?php endif; ?>
     </div><!-- /.rp-slider-wrapper -->
     <?php endif; ?>
 
-    <?php if ($layoutType === 'slider' && $thumbnailPosition !== 'disabled'): ?>
+    <?php if ($layoutType === 'slider' && $thumbnailPosition !== 'disabled' && !$isPlaceholder): ?>
     <div class="rp-thumbnail-strip" data-role="rp-thumbnails">
         <?php foreach ($images as $index => $image): ?>
             <?php

--- a/view/frontend/web/css/gallery-vertical.css
+++ b/view/frontend/web/css/gallery-vertical.css
@@ -1416,6 +1416,30 @@
 }
 
 /* ==============================================
+   Placeholder (no product images)
+   ============================================== */
+
+.rp-placeholder .rp-gallery-images {
+    display: flex;
+    flex-direction: column;
+}
+
+.rp-placeholder-item {
+    display: block;
+    text-align: center;
+    background: #f5f5f5;
+    border-radius: 4px;
+}
+
+.rp-placeholder-item img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 0 auto;
+    opacity: 0.6;
+}
+
+/* ==============================================
    Accessibility
    ============================================== */
 


### PR DESCRIPTION
## Summary
This change adds graceful placeholder image handling to the vertical gallery template when products have no images in their media gallery. Instead of rendering nothing, the gallery now displays Magento's built-in placeholder image with appropriate styling and disabled interactive features.

## Key Changes
- **Placeholder Detection**: Added logic to detect when a product has no images and retrieve the placeholder image from Magento's Gallery block data
- **Conditional Rendering**: Modified the gallery items loop to render either placeholder or actual product images based on availability
- **Disabled Interactive Features**: Zoom functionality is automatically disabled when displaying placeholder images
- **UI Adjustments**: 
  - Added `rp-placeholder` CSS class to the wrapper for placeholder-specific styling
  - Hidden slider navigation arrows and dots when in placeholder mode
  - Hidden thumbnail strip when in placeholder mode
- **Placeholder Styling**: Added new CSS rules for `.rp-placeholder` and `.rp-placeholder-item` classes with:
  - Flexbox layout for proper image centering
  - Light gray background (#f5f5f5) with subtle border radius
  - Reduced opacity (0.6) to visually distinguish placeholder from actual product images
  - Responsive sizing with `max-width: 100%` and `height: auto`

## Implementation Details
- The placeholder URL is retrieved from `$block->getGalleryImagesJson()` which provides Magento's fallback placeholder
- If no placeholder is available, the template returns early (maintains original behavior)
- All interactive gallery features (lightbox, zoom, slider navigation) are gracefully disabled for placeholder mode
- The implementation maintains backward compatibility with existing gallery functionality

https://claude.ai/code/session_01VQ4du3hXhKKjMEu6FzRAKx