### PR TITLE
fix: compatibilidad con Amasty_Label en la ficha de producto (IS-6206)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+## What's New in 1.8.7
+
+### Fixed — Amasty_Label labels did not render / positioned wrong on the PDP gallery
+
+On stores running both this module and `Amasty_Label`, product labels rendered fine in the category grid but misbehaved on the product page: (1) they did not render at all on the PDP, (2) when forced to render they appeared at the end of the gallery block instead of overlaid on the image, and (3) the label bled on top of dropdown menus, modals and other theme overlays. Detected and reproduced on Tienda Imco ([IS-6206](https://rollpix.atlassian.net/browse/IS-6206)); all three causes live in this module / its Amasty integration, not in the site.
+
+**Fix** (three coordinated changes):
+
+1. **`etc/frontend/di.xml`** — register the vertical gallery block name in Amasty's plugin allowlist. `Amasty\Label\Plugin\Catalog\Product\View\Label::afterToHtml` only emits the label HTML when `getNameInLayout()` is in an internal list (`product.info.media.image`, …). This module swaps the gallery for a block named `rollpix.product.gallery.vertical`, so the plugin silently skipped it. The name is injected via `<argument name="allowedNames">` (Amasty `array_merge`s it with its hardcoded list — the supported extension path, no `vendor/` patch).
+2. **`view/frontend/templates/product/view/gallery-vertical.phtml`** — add `id="amasty-main-container"` to `.rp-gallery-images`. `initLabel.js` relocates the label node into the first descendant matching `.fotorama__stage, #amasty-main-container`; the vertical gallery exposed neither, so the label stayed where the plugin injected it (end of block). The id gives Amasty a valid anchor to overlay the label on the image with no per-label config.
+3. **`view/frontend/templates/product/view/gallery-vertical.phtml`** — add `style="isolation: isolate;"` on the outer `.rp-product-gallery` wrapper. Amasty hardcodes `z-index: 995` on `.amlabel-position-wrapper`; most themes use far lower z-indexes for menu/header/modals, so the label punched through them. The isolation creates a stacking context that traps Amasty's 995 inside the gallery, letting any site element with `z-index > 0` paint above it. (It lives on the outer wrapper, not on `#amasty-main-container`, because `initLabel.js` overwrites that element's inline `style` via `this.parent.css('position', 'relative')`.)
+
+#### Files
+- `etc/frontend/di.xml` — `allowedNames` entry registering `rollpix.product.gallery.vertical` on `Amasty\Label\Plugin\Catalog\Product\View\Label`
+- `view/frontend/templates/product/view/gallery-vertical.phtml` — `id="amasty-main-container"` anchor + `isolation: isolate` on the wrapper
+
+---
+
 ## What's New in 1.8.6
 
 ### Changed — Swatch gallery now swaps on the first attribute alone (legacy fallback)

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Modern editorial-style product gallery for Magento 2 with vertical, grid, fashion and slider layouts, hover zoom, lightbox, sticky panel, thumbnail navigation, shimmer loading, fade-in animations, image counter, mobile carousel, and video support (MP4, YouTube, Vimeo) on product pages and category listings",
     "type": "magento2-module",
     "license": "MIT",
-    "version": "1.8.6",
+    "version": "1.8.7",
     "keywords": [
         "magento2",
         "magento",

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -28,4 +28,15 @@
                 type="Rollpix\ProductGallery\Plugin\Catalog\Block\Product\ListProduct\AddVideoDataPlugin"/>
     </type>
 
+
+    <!-- Amasty_Label compatibility: register the Rollpix vertical gallery block
+         name so Amasty's afterToHtml plugin renders PDP labels for it -->
+    <type name="Amasty\Label\Plugin\Catalog\Product\View\Label">
+        <arguments>
+            <argument name="allowedNames" xsi:type="array">
+                <item name="rollpix_gallery_vertical" xsi:type="string">rollpix.product.gallery.vertical</item>
+            </argument>
+        </arguments>
+    </type>
+
 </config>

--- a/view/frontend/templates/product/view/gallery-vertical.phtml
+++ b/view/frontend/templates/product/view/gallery-vertical.phtml
@@ -187,14 +187,14 @@ $gridImageColumns = $columnCss['gridImageColumns'] ?? 2;
 <?php endif; ?>
 
 <div class="<?= $block->escapeHtmlAttr(implode(' ', $wrapperClasses)) ?>"
-     data-role="rp-gallery"
+     style="isolation: isolate;" data-role="rp-gallery"
      data-mage-init='{"rpGalleryZoom": <?= /* @noEscape */ $jsConfig ?>, "rpGalleryCarousel": <?= /* @noEscape */ $jsConfig ?>, "rpGalleryTabs": <?= /* @noEscape */ $jsConfig ?>, "rpGalleryEffects": <?= /* @noEscape */ $jsConfig ?>, "rpGalleryThumbnails": <?= /* @noEscape */ $jsConfig ?>, "rpGallerySlider": <?= /* @noEscape */ $jsConfig ?>, "rpGalleryModalZoom": <?= /* @noEscape */ $jsConfig ?>, "rpGalleryCarouselZoom": <?= /* @noEscape */ $jsConfig ?>, "rpGalleryVideo": <?= /* @noEscape */ $jsConfig ?>}'>
 
     <?php if ($layoutType === 'slider'): ?>
     <div class="rp-slider-wrapper">
     <?php endif; ?>
 
-        <div class="rp-gallery-images">
+        <div class="rp-gallery-images" id="amasty-main-container">
             <?php if ($isPlaceholder): ?>
                 <span class="rp-gallery-item rp-placeholder-item">
                     <img src="<?= $block->escapeUrl($placeholderUrl) ?>"


### PR DESCRIPTION
## Resumen

Agrega tres ajustes para que `Rollpix_ProductGallery` conviva correctamente con `Amasty_Label` en la ficha de producto. Sin estos cambios, en cualquier tienda que use ambos módulos se observan tres síntomas:

1. Las etiquetas de Amasty no se renderizan en la PDP (aunque sí en la grilla de categoría).
2. Cuando se renderizan, aparecen al final del bloque de galería en vez de superpuestas a la imagen.
3. La etiqueta se "filtra" por encima de menús desplegados, modales y otros overlays del tema.

Detectado y reproducido en **Tienda Imco** (ticket [IS-6206](https://rollpix.atlassian.net/browse/IS-6206)), pero las tres causas viven íntegramente en este módulo o en su integración con Amasty — no son específicas del sitio.

## Cambios

### 1. `etc/frontend/di.xml` — registrar el nombre del bloque en el plugin de Amasty

El plugin `Amasty\Label\Plugin\Catalog\Product\View\Label::afterToHtml` solo renderiza el HTML del label cuando `getNameInLayout()` está en una lista interna (`product.info.media.image`, etc.). Como este módulo reemplaza la galería por un bloque llamado `rollpix.product.gallery.vertical`, el plugin descartaba la renderización en silencio.

Se inyecta el nombre vía `<argument name="allowedNames">` (Amasty hace `array_merge` con la lista hardcodeada en el constructor, así que es la vía de extensión soportada — no requiere parchear `vendor/`).

### 2. `view/frontend/templates/product/view/gallery-vertical.phtml` — anchor para `initLabel.js`

`initLabel.js` mueve el label DOM al primer descendiente que coincida con un selector CSS (por defecto `.fotorama__stage, #amasty-main-container`). La galería vertical no exponía ninguno → el label se quedaba donde el plugin lo inyecta (al final del bloque), sin poder superponerse a la imagen.

Se agrega `id="amasty-main-container"` al contenedor `.rp-gallery-images`. A partir de ahí Amasty posiciona el label correctamente sin configuración extra por etiqueta.

### 3. `view/frontend/templates/product/view/gallery-vertical.phtml` — `isolation: isolate` en el wrapper

Amasty hardcodea `z-index: 995` en `.amlabel-position-wrapper`. La mayoría de los temas usan z-index mucho más bajos para el menú/header/modales (en Tienda Imco el mega-menú está en `z-index: 99`), por lo que la etiqueta atravesaba esos overlays.

Se agrega `style="isolation: isolate;"` en el `<div class="rp-product-gallery ...">` exterior. Esto crea un contexto de apilamiento que encierra el 995 de Amasty dentro de la galería, dejando que cualquier elemento del sitio con `z-index > 0` pinte por encima.

**Nota técnica**: el `isolation` no funciona sobre el anchor `#amasty-main-container` porque `initLabel.js` sobrescribe el atributo `style` de ese elemento al hacer `this.parent.css('position', 'relative')`. Por eso vive en el wrapper exterior, que Amasty no toca.


[IS-6206]: https://rollpix.atlassian.net/browse/IS-6206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Amasty_Label labels not rendering or being mis-positioned on the product detail page gallery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->