### PR TITLE
fix: re-init carousel/lightbox zoom on variant swatch change (v1.8.8)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,20 @@
+## What's New in 1.8.7
+
+### Fixed — Carousel/lightbox zoom opened the raw image file after a variant change
+
+On a configurable PDP with the swatch → gallery bridge enabled (`rollpix_gallery/configurable/swatch_gallery_switch_enabled = Yes`), clicking a gallery image opened the zoom popup correctly — until a variant was selected. After picking a swatch option (e.g. a size), clicking an image navigated the browser straight to the raw image file (`/media/catalog/product/cache/…/*.jpg`) instead of opening the popup, with no way to close other than the browser Back button.
+
+**Root cause**: `gallery-carousel-zoom.js` collected its `.rp-gallery-item` set and bound its `click.rpcarouselzoom` (`preventDefault` + open modal) handlers **once at `domReady`, directly on the original anchor nodes**. When a swatch is selected, `swatch-gallery-bridge.js` replaces the gallery anchors with fresh nodes built from `jsonConfig.images[pid]` and fires `rollpix:gallery:dom_replaced`. The carousel-zoom component never listened for that event, so the replacement anchors carried no click handler and a click fell through to the native `href` — opening the raw image. (The bridge's own header already documented this as a known light-mode limitation: "Zoom widgets are not re-initialized… may behave unexpectedly after a swatch change.")
+
+**Fix**: `gallery-carousel-zoom.js` now encapsulates "collect media + bind triggers" in a `collectAndBind()` function called both at init **and** on `rollpix:gallery:dom_replaced`. On re-init it re-queries `.rp-gallery-item`, rebuilds the `media[]` list from the live DOM (so the popup shows the selected variant's images), and rebinds the namespaced click handler (`.off('click.rpcarouselzoom')` first; uses the live `$items.index(this)` so navigation order matches the current variant). Any cached overlay is torn down (`$overlay.remove(); $overlay = null`) so `buildModal()` re-renders the prev/next controls for the variant's image count, and `closeModal()` now guards against a null overlay. The listener is bound on the `[data-role="rp-gallery"]` element — the same node the bridge triggers the event on.
+
+Applies to both `carousel` and `lightbox` zoom types (which share this component). Hover zoom (`gallery-zoom.js`) has the same structural pattern but is out of scope for this release.
+
+#### Files
+- `view/frontend/web/js/gallery-carousel-zoom.js` — extracted `collectAndBind()`; re-runs on `rollpix:gallery:dom_replaced`; rebuilds `media[]`, rebinds namespaced click triggers, tears down cached overlay; null-safe `closeModal()`
+
+---
+
 ## What's New in 1.8.6
 
 ### Changed — Swatch gallery now swaps on the first attribute alone (legacy fallback)

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Modern editorial-style product gallery for Magento 2 with vertical, grid, fashion and slider layouts, hover zoom, lightbox, sticky panel, thumbnail navigation, shimmer loading, fade-in animations, image counter, mobile carousel, and video support (MP4, YouTube, Vimeo) on product pages and category listings",
     "type": "magento2-module",
     "license": "MIT",
-    "version": "1.8.6",
+    "version": "1.8.7",
     "keywords": [
         "magento2",
         "magento",

--- a/view/frontend/web/js/gallery-carousel-zoom.js
+++ b/view/frontend/web/js/gallery-carousel-zoom.js
@@ -4,6 +4,12 @@
  * Opens a modal overlay showing one image at a time with prev/next navigation.
  * Dark backdrop, close button, arrow keys support.
  *
+ * Re-initializes its media list and click triggers when the swatch -> gallery
+ * bridge replaces the gallery DOM on a configurable variant change
+ * (the `rollpix:gallery:dom_replaced` event). Without this the rebuilt
+ * `.rp-gallery-item` anchors carry no click handler, so a click falls through
+ * to the native href and the raw image file opens in the browser (IS-6367).
+ *
  * @category  Rollpix
  * @package   Rollpix_ProductGallery
  */
@@ -21,38 +27,10 @@ define([
             return;
         }
 
-        var $items = $gallery.find('.rp-gallery-item');
-        if ($items.length === 0) {
-            return;
-        }
-
-        // Collect media items
+        // Closure state, rebuilt by collectAndBind() on init and on every
+        // swatch-driven DOM replacement.
         var media = [];
-        $items.each(function () {
-            var $item = $(this);
-            var mediaType = $item.data('media-type') || 'image';
-
-            if (mediaType === 'video') {
-                var $source = $item.find('video source');
-                media.push({
-                    type: 'video',
-                    url: $source.attr('src') || '',
-                    alt: ''
-                });
-            } else {
-                media.push({
-                    type: 'image',
-                    url: $item.attr('href'),
-                    alt: $item.find('img').attr('alt') || ''
-                });
-            }
-        });
-
-        // Prevent default link behavior
-        $items.on('click', function (e) {
-            e.preventDefault();
-        });
-
+        var $items = $();
         var $overlay = null;
         var $stage = null;
         var $counter = null;
@@ -162,6 +140,9 @@ define([
             $(document).off('keydown.rpcarouselzoom');
 
             setTimeout(function () {
+                if (!$overlay) {
+                    return;
+                }
                 $overlay.css('display', 'none');
                 $('body').css('overflow', '');
                 $stage.empty();
@@ -196,18 +177,74 @@ define([
             });
         }
 
-        // Bind click on each gallery item
-        $items.each(function (index) {
-            $(this).on('click.rpcarouselzoom', function (e) {
-                e.preventDefault();
-                openModal(index);
+        // ----------------------------------------------------------
+        // (Re)collect the gallery items, rebuild the media list and
+        // (re)bind the click triggers. Safe to call repeatedly:
+        // handlers are namespaced and cleared first, and any cached
+        // overlay is torn down so buildModal() re-renders the prev/next
+        // controls for the current variant's image count.
+        // ----------------------------------------------------------
+        function collectAndBind() {
+            $items = $gallery.find('.rp-gallery-item');
+            if ($items.length === 0) {
+                return;
+            }
 
-                // Init swipe once overlay exists
-                if ($overlay && !$overlay.data('swipe-init')) {
-                    initSwipe();
-                    $overlay.data('swipe-init', true);
+            // Rebuild media from the live DOM.
+            media = [];
+            $items.each(function () {
+                var $item = $(this);
+                var mediaType = $item.data('media-type') || 'image';
+
+                if (mediaType === 'video') {
+                    var $source = $item.find('video source');
+                    media.push({
+                        type: 'video',
+                        url: $source.attr('src') || '',
+                        alt: ''
+                    });
+                } else {
+                    media.push({
+                        type: 'image',
+                        url: $item.attr('href'),
+                        alt: $item.find('img').attr('alt') || ''
+                    });
                 }
             });
-        });
+
+            // Tear down any cached overlay so the prev/next controls are
+            // rebuilt for the (possibly different) variant image count.
+            if ($overlay) {
+                $(document).off('keydown.rpcarouselzoom');
+                $('body').css('overflow', '');
+                $overlay.remove();
+                $overlay = null;
+                $stage = null;
+                $counter = null;
+            }
+            currentIndex = 0;
+
+            // Bind click on each gallery item (namespaced, idempotent).
+            $items
+                .off('click.rpcarouselzoom')
+                .on('click.rpcarouselzoom', function (e) {
+                    e.preventDefault();
+                    openModal($items.index(this));
+
+                    // Init swipe once overlay exists
+                    if ($overlay && !$overlay.data('swipe-init')) {
+                        initSwipe();
+                        $overlay.data('swipe-init', true);
+                    }
+                });
+        }
+
+        collectAndBind();
+
+        // The swatch -> gallery bridge replaces .rp-gallery-item anchors on a
+        // variant change and fires this event on [data-role="rp-gallery"]
+        // (same node as `element`). Re-collect + re-bind so the popup keeps
+        // working and shows the selected variant's images.
+        $gallery.on('rollpix:gallery:dom_replaced', collectAndBind);
     };
 });


### PR DESCRIPTION
## Problem (IS-6367)

On a configurable PDP with the swatch → gallery bridge enabled (`rollpix_gallery/configurable/swatch_gallery_switch_enabled = Yes`), clicking a gallery image opened the zoom popup correctly — **until** a variant was selected. After picking a swatch option (e.g. a size), clicking an image navigated the browser straight to the raw image file (`/media/catalog/product/cache/…/*.jpg`) instead of opening the popup, with no close button (only the browser Back button).

## Root cause

`gallery-carousel-zoom.js` collected its `.rp-gallery-item` set and bound its `click.rpcarouselzoom` (`preventDefault` + open modal) handlers **once at `domReady`, directly on the original anchor nodes**. When a swatch is selected, `swatch-gallery-bridge.js` replaces the gallery anchors with fresh nodes built from `jsonConfig.images[pid]` and fires `rollpix:gallery:dom_replaced`. The carousel-zoom component never listened for that event, so the replacement anchors carried **no click handler** and a click fell through to the native `href`.

The bridge's own header already flagged this as a known light-mode limitation: *"Zoom widgets are not re-initialized… may behave unexpectedly after a swatch change."*

## Fix

Encapsulate "collect media + bind triggers" in a `collectAndBind()` function, called at init **and** on `rollpix:gallery:dom_replaced`:

- re-query `.rp-gallery-item` and rebuild `media[]` from the **live DOM** (popup now shows the selected variant's images)
- rebind the namespaced click handler (`.off('click.rpcarouselzoom')` first; live `$items.index(this)` so navigation order matches the variant)
- tear down any cached overlay (`$overlay.remove(); $overlay = null`) so `buildModal()` re-renders prev/next for the variant's image count
- null-safe `closeModal()`

Listener is bound on the `[data-role="rp-gallery"]` element — the same node the bridge triggers the event on. Applies to both `carousel` and `lightbox` zoom types (shared component). Hover zoom (`gallery-zoom.js`) has the same pattern but is out of scope here.

## Testing

Verified live on Marcovecchio prod (the fix was applied in-place first, then ported here) with Playwright on `/fox-dirtpaw-31325`, all ✓:

1. Before any variant: click image → popup "1 / 3", no navigation (regression check)
2. After selecting M: click image → **popup opens** (was the bug), shows the M-variant image
3. Prev/next cycle 1→2→3→2; close restores page scroll
4. Switch M→L → re-binds, popup shows the L-variant image
5. Deselect → restores parent gallery, popup still works

No new JS console errors.

## Notes

- Repo HEAD was already at 1.8.6 (a swatch-bridge legacy-fallback fix not yet on prod), so this bumps to **1.8.7**.
- Base file (`gallery-carousel-zoom.js`) was byte-identical between repo HEAD and prod, so the patch applies cleanly.
- RELEASE_NOTES.md updated with a 1.8.7 entry.

Jira: IS-6367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed carousel and lightbox zoom on product pages so changing variants/swatches no longer navigates to raw image URLs and correctly opens the zoom popup (hover zoom unaffected).

* **Documentation**
  * Added "What's New in 1.8.8" release notes describing the fix.

* **Chores**
  * Bumped package version to 1.8.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->