### PR TITLE
fix(gallery): re-init slider/thumbnails/carousel/zoom on variant swap + viewport crossing (IS-6448)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ A modern, editorial-style product gallery module for Magento 2 that replaces the
 ### Configurable Variant Image Switch (Light Mode, Opt-In)
 - **Swatch → Gallery bridge**: on a configurable product PDP, selecting a swatch option (e.g. color) replaces the gallery images with the photos assigned to the matching child SKU. Implemented as a mixin over `Magento_Swatches/js/swatch-renderer` reading `jsonConfig.images[productId]`.
 - **Opt-in**: disabled by default. Enable under `Stores → Configuration → Rollpix → Product Gallery → Configurable Products → Swatch Gallery Image Switch (Light Mode)`.
-- **Shimmer-aware**: fires a `rollpix:gallery:dom_replaced` event so the shimmer effect re-detects the new items and does not get stuck.
-- **XSS-safe**: new items are built with the DOM API, not string concatenation.
+- **Widget-aware** (since 1.9.0): fires a `rollpix:gallery:dom_replaced` event so the Slider, Thumbnails, mobile Carousel, Shimmer and all Zoom types (hover/click in-place + modal/carousel/lightbox) re-initialize on the new variant images and keep working — across variant switches, deselect, and mobile↔desktop resizes. Also rebuilds the thumbnail strip to follow the selected variant.
+- **XSS-safe**: new items (and thumbnails) are built with the DOM API, not string concatenation.
 - **WebP-defensive**: preserves the `<picture class="mfwebp">` wrapper when present.
 - **Coexists with `Rollpix_ConfigurableGallery`**: both modules can be installed together. The light-mode bridge is gated entirely by the admin flag, so if the full-feature companion module is installed, simply leave this flag off and its richer bridge handles swatch changes instead.
-- **Known limitations**: Zoom / Slider / Thumbnail / Sticky widgets are NOT re-initialized on the new variant images. Videos are skipped on variants. Light mode is designed for stack layouts (Vertical / Grid / Fashion) with Zoom set to Lightbox / Modal Zoom / Disabled. For full support, install `Rollpix_ConfigurableGallery`.
+- **Known limitations**: Videos are skipped on variants. The scroll-aware Sticky panel is not explicitly re-initialized (it self-recalculates on scroll/resize). Under a WebP-optimization plugin (MageFan/Yireo), variant images may serve the non-WebP originals. For full feature parity, install `Rollpix_ConfigurableGallery`.
 
 ### Performance
 - **Lazy Loading**: Native lazy loading for images; IntersectionObserver for videos

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,36 @@
+## What's New in 1.9.0
+
+### Fixed — Slider / thumbnails / mobile carousel / zoom broke after a variant change (and across mobile↔desktop resizes)
+
+On a configurable PDP with the swatch → gallery bridge enabled (`rollpix_gallery/configurable/swatch_gallery_switch_enabled = Yes`) and a non-stack layout (Slider, or any layout on mobile where the Carousel takes over), selecting a swatch option left the gallery broken ([IS-6448](https://rollpix.atlassian.net/browse/IS-6448), Bordoli):
+
+- **Desktop slider** — the variant's images rendered as a full vertical stack instead of one-at-a-time; the prev/next arrows no longer moved the gallery; the dots were stale.
+- **Thumbnails** — the strip kept showing the **parent** product's thumbnails; they never followed the selected variant.
+- **Mobile carousel** — only the first image showed; the 2nd photo was no longer swipeable.
+- **Click / hover zoom** — after a variant change, clicking the image navigated the browser straight to the raw image file instead of zooming (same class of bug 1.8.8 fixed for modal/carousel/lightbox zoom; `gallery-zoom.js` was left out of scope then).
+- **Mobile ↔ desktop resize** — the slider never (re)activated when the viewport crossed the 767px breakpoint (it only set up once at load, and bailed on mobile), so resizing back to desktop — or loading on mobile then widening — left the images as a vertical stack on desktop. This affected slider-layout sites **even without** the swatch bridge.
+
+**Root cause**: `swatch-gallery-bridge.js` replaced `.rp-gallery-images` (via `$container.empty()` + append of fresh nodes) and fired `rollpix:gallery:dom_replaced`, but only `gallery-effects.js` (shimmer) and `gallery-carousel-zoom.js` listened for it. `gallery-slider.js`, `gallery-thumbnails.js`, `gallery-carousel.js` and `gallery-zoom.js` cached their `.rp-gallery-item` / `.rp-thumbnail-item` sets and bound their handlers **once at init**, so after the swap the new items carried no slider display state, the arrows/dots/thumbnail/zoom handlers stayed bound to the detached original nodes, the mobile `.rp-carousel-track` was wiped, and the bridge never rebuilt the thumbnail strip at all. Separately, the slider had no viewport-crossing logic (the mobile carousel did).
+
+**Fix** (extends the v1.8.8 `collectAndBind()` re-init pattern to the remaining widgets):
+
+1. **`gallery-slider.js`** — init wrapped in idempotent `setup()`/`teardown()`; re-runs on `rollpix:gallery:dom_replaced`. **Also** made viewport-aware (mirrors `gallery-carousel.js`): a debounced window-resize handler activates the slider when the viewport is desktop and deactivates it (clearing per-item inline styles for the carousel) when it crosses to mobile — both directions, regardless of the initial viewport. Teardown offs all `.rpslider`-namespaced handlers and empties the dots; setup re-queries items/thumbnails, resets `currentIndex`, rebuilds dots and re-applies the one-visible state.
+2. **`gallery-thumbnails.js`** — same `setup()`/`teardown()` split; re-runs on the event. The `IntersectionObserver` is disconnected and the sliding `.rp-thumbnail-highlight` re-created on each swap (no duplicate highlights). Handlers namespaced `.rpthumbs`.
+3. **`gallery-carousel.js`** (mobile) — listens for the event, resets its flags/classes (the bridge wiped its track) and re-runs the viewport check to rebuild a fresh track + indicators from the variant's images.
+4. **`gallery-zoom.js`** — `setup()`/`teardown()` + re-init on the event for both hover (magnifier) and click (in-place) zoom; added an immediate `preventDefault` guard on each item so a click during the large-image load window can never fall through to the anchor `href` (the raw file).
+5. **`swatch-gallery-bridge.js`** — now rebuilds the **thumbnail strip** (`.rp-thumbnail-item`) from the same `jsonConfig.images[pid]` set as the main images (using `img.thumb`), in DOM-node form (XSS-safe), preserving the JS-managed highlight node; snapshots the original thumbnails and restores them (alongside the images) when the selection is cleared.
+
+Net effect: Slider, Thumbnails, the mobile Carousel and all Zoom types now keep working across variant switches, on deselect, and across mobile↔desktop resizes — no longer limited to stack layouts. The scroll-aware Sticky panel is still not explicitly re-initialized (it self-recalculates on scroll/resize via its own MutationObserver). **JS-only change** — no PHP / template / layout / CSS / admin changes; behavior with the bridge disabled (the default) is unchanged.
+
+#### Files
+- `view/frontend/web/js/gallery-slider.js` — `setup()`/`teardown()`, re-init on event + mobile↔desktop viewport crossing
+- `view/frontend/web/js/gallery-thumbnails.js` — `setup()`/`teardown()`, observer/highlight re-init
+- `view/frontend/web/js/gallery-carousel.js` — rebuild mobile carousel on the event
+- `view/frontend/web/js/gallery-zoom.js` — re-init hover/click zoom + immediate click guard
+- `view/frontend/web/js/swatch-gallery-bridge.js` — rebuild + snapshot/restore the thumbnail strip; updated header docs
+
+---
+
 ## What's New in 1.8.8
 
 ### Fixed — Carousel/lightbox zoom opened the raw image file after a variant change

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Modern editorial-style product gallery for Magento 2 with vertical, grid, fashion and slider layouts, hover zoom, lightbox, sticky panel, thumbnail navigation, shimmer loading, fade-in animations, image counter, mobile carousel, and video support (MP4, YouTube, Vimeo) on product pages and category listings",
     "type": "magento2-module",
     "license": "MIT",
-    "version": "1.8.8",
+    "version": "1.9.0",
     "keywords": [
         "magento2",
         "magento",

--- a/view/frontend/web/js/gallery-carousel.js
+++ b/view/frontend/web/js/gallery-carousel.js
@@ -29,6 +29,27 @@ define([
 
         init();
 
+        // Rebuild the carousel when the swatch → gallery bridge swaps the
+        // images for a different variant. The bridge does $container.empty()
+        // on .rp-gallery-images, which destroys the .rp-carousel-track and
+        // appends the new items as bare children — leaving the carousel
+        // "active" but with an empty track, so only the first image showed
+        // and swipe/dots broke (IS-6448). We can't call destroyCarousel()
+        // (its $track/$items refs are now detached); instead reset the
+        // structure flags and re-run the viewport check to rebuild fresh.
+        $gallery.on('rollpix:gallery:dom_replaced.rpcarouselreinit', function () {
+            if (mobileBehavior !== 'carousel') {
+                return;
+            }
+            isCarouselInitialized = false;
+            currentIndex = 0;
+            $gallery.removeClass('rp-carousel-active');
+            $gallery.find('.rp-gallery-images')
+                .removeClass('rp-carousel-wrapper')
+                .css('height', '');
+            checkViewport();
+        });
+
         function init() {
             checkViewport();
             $(window).on('resize', debounce(checkViewport, 250));

--- a/view/frontend/web/js/gallery-slider.js
+++ b/view/frontend/web/js/gallery-slider.js
@@ -5,6 +5,13 @@
  * navigation arrows, dots, mouse wheel, and keyboard support.
  * Desktop only - on mobile, the carousel component takes over.
  *
+ * Re-initializes on `rollpix:gallery:dom_replaced` so the slider keeps
+ * working after the swatch → gallery bridge swaps the images (and
+ * thumbnails) for a different variant on a configurable PDP. Without
+ * this the rebuilt items carried no inline display state (all visible =
+ * vertical stack) and the arrows/dots/thumbnails stayed bound to the
+ * detached original nodes (IS-6448).
+ *
  * @category  Rollpix
  * @package   Rollpix_ProductGallery
  */
@@ -22,9 +29,10 @@ define([
             return;
         }
 
-        if (window.innerWidth <= 767) {
-            return;
-        }
+        // NB: no early mobile return — viewport crossings are handled below
+        // so the slider de/activates as the user resizes across the
+        // breakpoint, where the mobile carousel component takes over.
+        var MOBILE_BP = 767;
 
         var sliderConfig = config.slider || {};
         var direction = sliderConfig.direction || 'horizontal';
@@ -33,31 +41,119 @@ define([
         var showDots = sliderConfig.dots !== false;
         var enableMouseWheel = sliderConfig.mousewheel !== false;
 
+        // Stable wrapper/control elements (siblings of the images list —
+        // not touched by the swatch bridge, so they're cached once).
         var $imagesContainer = $gallery.find('.rp-gallery-images');
-        var $items = $imagesContainer.find('.rp-gallery-item');
         var $prevBtn = $gallery.find('.rp-slider-prev');
         var $nextBtn = $gallery.find('.rp-slider-next');
         var $dotsContainer = $gallery.find('.rp-slider-dots');
-        var $thumbnails = $gallery.find('.rp-thumbnail-item');
+
+        // Per-image state — recomputed by setup() on init and on every
+        // variant swap (the .rp-gallery-item / .rp-thumbnail-item nodes
+        // are replaced by the bridge).
+        var $items, $thumbnails, itemAspectRatios;
         var currentIndex = 0;
-        var totalImages = $items.length;
+        var totalImages = 0;
         var isAnimating = false;
+        var isActive = false;
 
         var allTransitionClasses = 'rp-slide-enter rp-slide-active rp-slide-exit ' +
             'rp-slide-enter-left rp-slide-enter-right rp-slide-enter-up rp-slide-enter-down ' +
             'rp-zoom-enter rp-zoom-enter-active rp-zoom-exit';
 
-        if (totalImages <= 0) {
-            return;
+        if (window.innerWidth > MOBILE_BP) {
+            setup();
         }
 
-        // Cache aspect-ratios from template inline styles so they survive style resets
-        var itemAspectRatios = [];
-        $items.each(function () {
-            itemAspectRatios.push(this.style.aspectRatio || '');
+        // Re-initialize when the swatch → gallery bridge replaces the
+        // images/thumbnails for a different variant. Namespaced
+        // separately from the inner '.rpslider' handlers so teardown()
+        // (which offs '.rpslider') never unbinds this listener.
+        $gallery.on('rollpix:gallery:dom_replaced.rpsliderreinit', function () {
+            // On mobile the carousel component owns the gallery, so the
+            // slider must stay out (just clear our state).
+            if (window.innerWidth <= MOBILE_BP) {
+                deactivate();
+                return;
+            }
+            setup();
         });
 
-        init();
+        // De/activate as the viewport crosses the mobile breakpoint
+        // (mirrors gallery-carousel.js, which inits/destroys its carousel
+        // the same way). Debounced slightly longer than the carousel's
+        // 250ms so on mobile→desktop the carousel finishes destroying its
+        // track before we re-init, and on desktop→mobile we clear our
+        // inline item styles after the carousel has wrapped the items.
+        // Kept out of the '.rpslider' namespace so teardown() never drops it.
+        $(window).on('resize.rpsliderwin', debounce(function () {
+            if (window.innerWidth > MOBILE_BP) {
+                if (!isActive) {
+                    setup();
+                }
+            } else if (isActive) {
+                deactivate();
+            }
+        }, 300));
+
+        /**
+         * (Re)bind everything against the current DOM. Idempotent: tears
+         * down prior handlers/state first so it can run on every swap.
+         */
+        function setup() {
+            teardown();
+
+            $items = $imagesContainer.find('.rp-gallery-item');
+            $thumbnails = $gallery.find('.rp-thumbnail-item');
+            currentIndex = 0;
+            isAnimating = false;
+            totalImages = $items.length;
+
+            if (totalImages <= 0) {
+                return;
+            }
+
+            // Cache aspect-ratios from template inline styles so they survive style resets
+            itemAspectRatios = [];
+            $items.each(function () {
+                itemAspectRatios.push(this.style.aspectRatio || '');
+            });
+
+            init();
+            isActive = true;
+        }
+
+        /**
+         * Remove every handler/state this component added so a re-init on
+         * the next variant starts clean (no double-bound arrows, no
+         * duplicated dots, no stale thumbnail handlers).
+         */
+        function teardown() {
+            $gallery.off('.rpslider');
+            $imagesContainer.off('.rpslider');
+            $prevBtn.off('.rpslider');
+            $nextBtn.off('.rpslider');
+            $dotsContainer.off('.rpslider').empty().show();
+            // Live thumbnails (the bridge has already rebuilt them by the
+            // time this runs on a swap); detached old ones are harmless.
+            $gallery.find('.rp-thumbnail-item').off('.rpslider');
+            $gallery.removeAttr('tabindex');
+            $imagesContainer.css('min-height', '');
+            isActive = false;
+        }
+
+        /**
+         * Hand the gallery over to the mobile carousel: drop slider
+         * handlers and clear the per-item inline display/transition state
+         * so the carousel track can show every slide.
+         */
+        function deactivate() {
+            teardown();
+            if ($items) {
+                $items.attr('style', '').removeClass(allTransitionClasses);
+            }
+            $imagesContainer.css('min-height', '');
+        }
 
         function init() {
             // Force-load all images: display:none prevents lazy loading
@@ -86,6 +182,8 @@ define([
                 $prevBtn.hide();
                 $nextBtn.hide();
             } else {
+                $prevBtn.show();
+                $nextBtn.show();
                 $prevBtn.on('click.rpslider', function (e) {
                     e.preventDefault();
                     e.stopPropagation();
@@ -154,6 +252,7 @@ define([
         }
 
         function buildDots() {
+            $dotsContainer.show();
             for (var i = 0; i < totalImages; i++) {
                 var $dot = $('<button class="rp-slider-dot" type="button"></button>');
                 $dot.attr('aria-label', 'Go to image ' + (i + 1));
@@ -332,7 +431,7 @@ define([
         }
 
         function updateThumbnailActive() {
-            if ($thumbnails.length) {
+            if ($thumbnails && $thumbnails.length) {
                 $thumbnails.removeClass('rp-thumbnail-active');
                 $thumbnails.eq(currentIndex).addClass('rp-thumbnail-active');
             }
@@ -348,15 +447,6 @@ define([
                 }
             };
         }
-
-        // Handle resize: if resizing to mobile, reset all items
-        $(window).on('resize.rpslider', debounce(function () {
-            if (window.innerWidth <= 767) {
-                $items.attr('style', '');
-                $items.removeClass(allTransitionClasses);
-                $imagesContainer.css('min-height', '');
-            }
-        }, 250));
 
         function debounce(func, wait) {
             var timeout;

--- a/view/frontend/web/js/gallery-thumbnails.js
+++ b/view/frontend/web/js/gallery-thumbnails.js
@@ -5,6 +5,12 @@
  * For slider layout, tracking and clicks are handled by gallery-slider.js.
  * Desktop only (hidden on mobile via CSS).
  *
+ * Re-initializes on `rollpix:gallery:dom_replaced` so the strip keeps
+ * tracking the correct images after the swatch → gallery bridge rebuilds
+ * the thumbnails (and images) for a different variant on a configurable
+ * PDP — otherwise the observer/highlight stayed bound to the detached
+ * parent thumbnails (IS-6448).
+ *
  * @category  Rollpix
  * @package   Rollpix_ProductGallery
  */
@@ -27,17 +33,53 @@ define([
             return;
         }
 
-        var $items = $gallery.find('.rp-gallery-item');
-        var $thumbnails = $gallery.find('.rp-thumbnail-item');
+        // The strip wrapper is stable; its .rp-thumbnail-item children are
+        // rebuilt by the swatch bridge, so they're re-queried in setup().
         var $strip = $gallery.find('.rp-thumbnail-strip');
 
-        if (!$items.length || !$thumbnails.length) {
-            return;
+        var $items, $thumbnails, $highlight, observer;
+
+        setup();
+
+        // Re-run when the swatch bridge swaps the variant's thumbnails.
+        $gallery.on('rollpix:gallery:dom_replaced.rpthumbsreinit', function () {
+            if (window.innerWidth <= 767) {
+                teardown();
+                return;
+            }
+            setup();
+        });
+
+        function setup() {
+            teardown();
+
+            $items = $gallery.find('.rp-gallery-item');
+            $thumbnails = $gallery.find('.rp-thumbnail-item');
+
+            if (!$items.length || !$thumbnails.length) {
+                return;
+            }
+
+            initThumbnailTracking();
+            initThumbnailClicks();
+            initHighlight();
         }
 
-        initThumbnailTracking();
-        initThumbnailClicks();
-        initHighlight();
+        function teardown() {
+            if (observer) {
+                observer.disconnect();
+                observer = null;
+            }
+            // Drop this component's handlers on any live thumbnails and
+            // the slider-change listener, and remove the highlight node so
+            // re-init doesn't stack duplicates.
+            $gallery.find('.rp-thumbnail-item').off('.rpthumbs');
+            $gallery.off('rpslider:change.rpthumbs');
+            if ($highlight) {
+                $highlight.remove();
+                $highlight = null;
+            }
+        }
 
         function initThumbnailTracking() {
             // Slider JS manages active thumbnail state
@@ -49,7 +91,7 @@ define([
                 return;
             }
 
-            var observer = new IntersectionObserver(function (entries) {
+            observer = new IntersectionObserver(function (entries) {
                 entries.forEach(function (entry) {
                     if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
                         var index = $items.index(entry.target);
@@ -76,7 +118,7 @@ define([
                 return;
             }
 
-            $thumbnails.on('click', function () {
+            $thumbnails.on('click.rpthumbs', function () {
                 var index = $(this).data('thumb-index');
                 var $targetItem = $items.eq(index);
 
@@ -94,8 +136,6 @@ define([
         // =========================================
         // SLIDING HIGHLIGHT INDICATOR
         // =========================================
-        var $highlight = null;
-
         function initHighlight() {
             $highlight = $('<div class="rp-thumbnail-highlight"></div>');
             $strip.append($highlight);
@@ -108,7 +148,7 @@ define([
 
             // For slider layout, listen to slider change events
             if (layoutType === 'slider') {
-                $gallery.on('rpslider:change', function (e, currentIndex) {
+                $gallery.on('rpslider:change.rpthumbs', function (e, currentIndex) {
                     var $thumb = $thumbnails.eq(currentIndex);
                     scrollThumbIntoView($thumb);
                     moveHighlight($thumb);

--- a/view/frontend/web/js/gallery-zoom.js
+++ b/view/frontend/web/js/gallery-zoom.js
@@ -3,6 +3,14 @@
  *
  * Supports: hover (magnifier), click (in-place), disabled
  *
+ * Re-initializes on `rollpix:gallery:dom_replaced` so zoom keeps working
+ * after the swatch → gallery bridge swaps the images for a different
+ * variant on a configurable PDP. Without this the rebuilt
+ * `.rp-gallery-item` anchors carried no zoom handler and a click fell
+ * through to the anchor's `href` — opening the raw image file (IS-6448).
+ * Mirrors the v1.8.8 fix in gallery-carousel-zoom.js for the modal/
+ * carousel/lightbox zoom types.
+ *
  * @category  Rollpix
  * @package   Rollpix_ProductGallery
  */
@@ -22,13 +30,39 @@ define([
             return;
         }
 
-        if (zoomType === 'click') {
-            initClickZoom();
-            return;
+        setup();
+
+        // Re-run when the swatch → gallery bridge replaces the images for
+        // a different variant.
+        $gallery.on('rollpix:gallery:dom_replaced.rpzoomreinit', function () {
+            setup();
+        });
+
+        /**
+         * (Re)bind zoom against the current images. Idempotent: clears any
+         * prior zoom DOM/handlers first so it can run on every swap.
+         */
+        function setup() {
+            teardown();
+            if (zoomType === 'click') {
+                initClickZoom();
+            } else {
+                initHoverZoom();
+            }
         }
 
-        // Default: hover zoom
-        initHoverZoom();
+        function teardown() {
+            $gallery.find('.rp-gallery-item').off('.rpzoom')
+                .removeClass('rp-click-zoom-item rp-click-zoomed');
+            // Undo hover-zoom wrappers + lenses and click-zoom overlays.
+            $gallery.find('.rp-zoom-wrapper').each(function () {
+                $(this).find('.rp-gallery-item').unwrap();
+            });
+            $gallery.find('.rp-zoom-lens, .rp-zoom-result-inside, .rp-click-zoom-overlay').remove();
+            // Shared hover result panel lives on <body> — drop it so swaps
+            // don't stack multiple copies.
+            $('.rp-zoom-result-fixed').remove();
+        }
 
         /* ===========================================================
            HOVER ZOOM - Magnifier lens + result panel
@@ -48,7 +82,10 @@ define([
                 var $img = $item.find('img');
                 var largeImageUrl = $item.attr('href');
 
-                $item.on('click', function (e) {
+                // Immediate guard: never let a click on the gallery image
+                // navigate to the raw file, even before the large image
+                // below has loaded and the behaviour handlers are bound.
+                $item.on('click.rpzoom', function (e) {
                     e.preventDefault();
                 });
 
@@ -179,6 +216,12 @@ define([
                 var $img = $item.find('img');
                 var largeImageUrl = $item.attr('href');
                 var isZoomed = false;
+
+                // Immediate guard: never let a click navigate to the raw
+                // file, even before the large image loads below.
+                $item.on('click.rpzoom', function (e) {
+                    e.preventDefault();
+                });
 
                 // Create overlay for zoomed view
                 var $zoomOverlay = $('<div class="rp-click-zoom-overlay"></div>');

--- a/view/frontend/web/js/swatch-gallery-bridge.js
+++ b/view/frontend/web/js/swatch-gallery-bridge.js
@@ -18,16 +18,21 @@
  * is enough to swap the gallery without forcing the merchant to touch
  * admin flags.
  *
+ * On a swap this rebuilds both the main images (.rp-gallery-images) and
+ * the thumbnail strip (.rp-thumbnail-item) from jsonConfig.images[pid],
+ * then fires `rollpix:gallery:dom_replaced` on the gallery node. The
+ * layout/zoom widgets listen for that event and re-initialize against the
+ * new DOM, so Slider, Thumbnails, mobile Carousel, Shimmer, all Zoom
+ * types (hover/click in-place + modal/carousel/lightbox) and viewport
+ * (mobile↔desktop) changes all keep working after a variant switch
+ * (IS-6448).
+ *
  * ⚠ LIMITATIONS — see etc/adminhtml/system.xml (configurable group
  * comment) and README.md ("Configurable variant image switch") for the
- * full list. This is explicitly a *light* mode:
+ * full list. This is still a *light* mode:
  *   - Only still images are switched (videos are skipped on variants).
- *   - Zoom widgets (hover/click) are not re-initialized and may behave
- *     unexpectedly after a swatch change. Recommend Lightbox / Modal
- *     Zoom / Disabled for configurable PDPs.
- *   - Slider / carousel / thumbnail / sticky widgets are not
- *     re-initialized — the light mode is designed for stack layouts
- *     (Vertical / Grid / Fashion).
+ *   - The scroll-aware Sticky panel is not explicitly re-initialized; it
+ *     self-recalculates on scroll/resize via its own MutationObserver.
  *   - Under a WebP-optimization plugin (MageFan mfwebp, Yireo WebP2),
  *     variant images may be served as the non-WebP originals.
  *
@@ -61,6 +66,9 @@ define(['jquery'], function ($) {
             /** Original gallery HTML, saved on first swatch interaction. */
             _rpOriginalItemsHtml: null,
 
+            /** Original thumbnail-item buttons (outerHTML), saved alongside. */
+            _rpOriginalThumbsHtml: null,
+
             /** Last child product id whose images were pushed into the gallery. */
             _rpLastSyncedProductId: null,
 
@@ -91,10 +99,16 @@ define(['jquery'], function ($) {
                     return;
                 }
 
-                // Snapshot original parent gallery on first interaction so
-                // we can restore it when the selection is cleared.
+                // Snapshot original parent gallery + thumbnails on first
+                // interaction so we can restore them when the selection is
+                // cleared. Only the .rp-thumbnail-item buttons are captured
+                // (not the JS-managed .rp-thumbnail-highlight node).
                 if (this._rpOriginalItemsHtml === null) {
                     this._rpOriginalItemsHtml = $container.html();
+                    var origThumbs = '';
+                    $gallery.find('.rp-thumbnail-strip .rp-thumbnail-item')
+                        .each(function () { origThumbs += this.outerHTML; });
+                    this._rpOriginalThumbsHtml = origThumbs;
                 }
 
                 var productIds = this._rpMatchedProducts();
@@ -103,6 +117,7 @@ define(['jquery'], function ($) {
                     // No full selection yet → restore parent gallery.
                     if (this._rpLastSyncedProductId !== null) {
                         $container.html(this._rpOriginalItemsHtml);
+                        this._rpRestoreThumbnails($gallery);
                         this._rpLastSyncedProductId = null;
                         this._rpFireDomReplaced($gallery);
                     }
@@ -306,6 +321,10 @@ define(['jquery'], function ($) {
 
                 var frag = document.createDocumentFragment();
                 var appended = 0;
+                // Images that actually made it into the gallery, in order,
+                // so the thumbnail strip can be rebuilt from the exact same
+                // set (same skip rules) and indices stay aligned.
+                var usable = [];
 
                 $.each(images, function (i, img) {
                     // Videos cannot be reliably reconstructed from
@@ -316,6 +335,8 @@ define(['jquery'], function ($) {
                     if (!img || !img.img) {
                         return;
                     }
+
+                    usable.push(img);
 
                     var anchor = document.createElement('a');
                     anchor.className = 'rp-gallery-item';
@@ -353,7 +374,76 @@ define(['jquery'], function ($) {
                 $container.empty();
                 $container[0].appendChild(frag);
 
+                this._rpRebuildThumbnails($gallery, usable, altBase);
+
                 this._rpFireDomReplaced($gallery);
+            },
+
+            // ----------------------------------------------------------
+            // Rebuild the .rp-thumbnail-item buttons in the thumbnail
+            // strip from the same usable images as the main gallery, so a
+            // variant switch updates the thumbnails too (previously the
+            // strip kept the parent's thumbs — IS-6448). The JS-managed
+            // .rp-thumbnail-highlight node is preserved; gallery-thumbnails
+            // re-creates it on `rollpix:gallery:dom_replaced`. DOM nodes
+            // (not string concat) to stay XSS-safe on image URLs.
+            // ----------------------------------------------------------
+            _rpRebuildThumbnails: function ($gallery, usable, altBase) {
+                var $strip = $gallery.find('.rp-thumbnail-strip').first();
+                if (!$strip.length || !usable.length) {
+                    return;
+                }
+
+                $strip.find('.rp-thumbnail-item').remove();
+
+                var frag = document.createDocumentFragment();
+                usable.forEach(function (img, idx) {
+                    var btn = document.createElement('button');
+                    btn.type = 'button';
+                    btn.className = 'rp-thumbnail-item' +
+                        (idx === 0 ? ' rp-thumbnail-active' : '');
+                    btn.setAttribute('data-thumb-index', String(idx));
+
+                    var imgEl = document.createElement('img');
+                    imgEl.src = img.thumb || img.img;
+                    imgEl.alt = altBase;
+                    imgEl.loading = 'lazy';
+
+                    btn.appendChild(imgEl);
+                    frag.appendChild(btn);
+                });
+
+                // Keep the new buttons ahead of the absolutely-positioned
+                // highlight node (if present) so DOM order matches the
+                // gallery items.
+                var highlight = $strip[0].querySelector('.rp-thumbnail-highlight');
+                if (highlight) {
+                    $strip[0].insertBefore(frag, highlight);
+                } else {
+                    $strip[0].appendChild(frag);
+                }
+            },
+
+            // ----------------------------------------------------------
+            // Restore the parent product's original thumbnail buttons when
+            // the swatch selection is cleared. Mirrors the images restore
+            // ($container.html(originalItems)) in _rpSyncGallery.
+            // ----------------------------------------------------------
+            _rpRestoreThumbnails: function ($gallery) {
+                if (this._rpOriginalThumbsHtml === null) {
+                    return;
+                }
+                var $strip = $gallery.find('.rp-thumbnail-strip').first();
+                if (!$strip.length) {
+                    return;
+                }
+                $strip.find('.rp-thumbnail-item').remove();
+                var highlight = $strip[0].querySelector('.rp-thumbnail-highlight');
+                if (highlight) {
+                    $(this._rpOriginalThumbsHtml).insertBefore(highlight);
+                } else {
+                    $strip.append(this._rpOriginalThumbsHtml);
+                }
             },
 
             // ----------------------------------------------------------


### PR DESCRIPTION
## IS-6448 — Bordoli

On a configurable PDP with the swatch → gallery bridge enabled (`swatch_gallery_switch_enabled = Yes`) and a non-stack layout (Slider, or any layout on mobile), selecting a swatch broke the gallery:

- Desktop slider → images shown as a **vertical stack**, dead arrows/dots
- **Thumbnails** kept showing the parent product's images
- Mobile **carousel** → 2nd image no longer swipeable
- **Click/hover zoom** → clicking the image navigated to the raw image file
- **Mobile↔desktop resize** → slider never (re)activated on desktop (vertical stack)

### Root cause
The bridge rebuilt `.rp-gallery-images` and fired `rollpix:gallery:dom_replaced`, but only shimmer + carousel-zoom listened. The slider/thumbnails/carousel/zoom widgets cached their nodes and bound handlers once at init; the bridge also never rebuilt the thumbnail strip. The slider additionally had no viewport-crossing logic.

### Fix (JS-only)
- **gallery-slider.js** — idempotent `setup()`/`teardown()`, re-init on the event + mobile↔desktop viewport crossing (mirrors gallery-carousel.js)
- **gallery-thumbnails.js** — `setup()`/`teardown()`, observer + highlight re-init
- **gallery-carousel.js** — rebuild the mobile track on the event
- **gallery-zoom.js** — re-init hover/click zoom + immediate `preventDefault` guard
- **swatch-gallery-bridge.js** — rebuild the thumbnail strip from `jsonConfig.images`; snapshot/restore on deselect

No PHP/template/layout/CSS/admin changes. **With the bridge disabled (the default), behavior is unchanged** (verified). Bump 1.8.8 → 1.9.0.

### Verified on stage (Playwright, bordoli ishop16)
- Variant switch: slider 1 visible, arrows/dots/thumbnails in sync, thumbnails follow variant
- Mobile carousel track rebuilt; multi-switch (no dup highlights); deselect restores parent
- Click-zoom no longer opens the raw file
- mobile↔desktop resize works both directions, with and without a variant
- **Bridge OFF**: variant selection does not swap (old behavior), nothing breaks, 0 console errors
- 0 JS console errors across all scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Variant changes now refresh the gallery more reliably, including images, thumbnails, mobile carousel, and zoom views.
  * The gallery now better adapts when switching between mobile and desktop layouts.

* **Bug Fixes**
  * Fixed broken gallery state after changing product variants or resizing the browser.
  * Improved thumbnail and zoom behavior so selected variants stay in sync.
  * Added safer image handling to avoid unexpected navigation or broken displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->